### PR TITLE
requirements.txt, versions >= instead of ==

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,9 @@
 -f https://download.pytorch.org/whl/torch_stable.html
-torch==1.10.1
-torchaudio==0.10.1
-soundfile==0.10.3.post1
+torch>=1.10.1
+torchaudio>=0.10.1
+soundfile>=0.10.3.post1
 omegaconf
-epitran==1.15
+epitran>=1.15
 audioread
 requests
 dtwalign
@@ -15,4 +15,4 @@ pickle-mixin
 sqlalchemy
 transformers
 sentencepiece
-ortools==9.2.9972
+ortools>=9.2.9972


### PR DESCRIPTION
In the requirements.txt file, I just changed operator `==` to `>=`, to let the pip installer to use more recent versions of the listed libraries, given that some of the originally listed are not working with more recent Python versions.